### PR TITLE
バッチモードで動かないように

### DIFF
--- a/Editor/ToolbarExtension.cs
+++ b/Editor/ToolbarExtension.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEditor;
+using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace YujiAp.UnityToolbarExtension.Editor
@@ -19,6 +20,11 @@ namespace YujiAp.UnityToolbarExtension.Editor
 
         static ToolbarExtension()
         {
+            if (Application.isBatchMode)
+            {
+                return;
+            }
+
             EditorApplication.update -= OnUpdate;
             EditorApplication.update += OnUpdate;
         }


### PR DESCRIPTION
Unity testrunnerをbatchmodeで動かすとエラーになってtestrunnerが走らないので、batchmodeでは動かないようにしました。